### PR TITLE
Feature: ability to search non-recursively

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,14 +133,6 @@ Returns a FileHound instance.
 ##### Returns
 Returns a Promise of all matches. If the Promise fulfills, the fulfillment value is an array of all matching files.
 
-### `FileHound.not(FileHound...) -> Promise`
-
-##### Parameters
-* Accepts one or more instances of FileHound to negate. Will unpack an array.
-
-##### Returns
-* If the Promise fulfills, the fulfillment value is an array of negated matches
-
 ## Instance methods
 
 ### `.paths(paths...) -> FileHound`
@@ -157,6 +149,14 @@ Directories to search. Accepts one or more directories or a reference to an arra
 
 ##### Parameters
 * extension - file extension to filter by
+
+##### Returns
+* Returns a FileHound instance
+
+### `.recursive(bool) -> FileHound`
+
+##### Parameters
+* bool _default true_ - a boolean indicating whether to search recursively
 
 ##### Returns
 * Returns a FileHound instance

--- a/lib/filehound.js
+++ b/lib/filehound.js
@@ -28,6 +28,7 @@ class FileHound {
     this.searchPaths = new Set();
     this.searchPaths.add(process.cwd());
     this.filters = [];
+    this.recursion = true;
   }
 
   static create() {
@@ -65,6 +66,12 @@ class FileHound {
     return this;
   }
 
+  recursive(r) {
+    r = typeof r === 'undefined' ? true : r;
+    this.recursion = r;
+    return this;
+  }
+
   size(sizeExpression) {
     this.addFilter(sizeMatcher(sizeExpression));
     return this;
@@ -88,7 +95,7 @@ class FileHound {
   search(dir) {
     return this._getFiles(dir)
       .map((file) => {
-        return isDirectory(file) ? this.search(file) : file;
+        return (this.recursion && isDirectory(file)) ? this.search(file) : file;
       })
       .reduce(flatten, [])
       .filter((file) => {

--- a/test/filehound.js
+++ b/test/filehound.js
@@ -5,6 +5,7 @@ const path = require('path');
 
 const justFiles = qualifyNames(['/justFiles/a.json', '/justFiles/b.json', '/justFiles/dummy.txt']);
 const nestedFiles = qualifyNames(['/nested/c.json', 'nested/d.json', '/nested/mydir/e.json']);
+const nestedFilesNonRecursive = qualifyNames(['/nested/c.json', 'nested/d.json']);
 const textFiles = qualifyNames(['/justFiles/dummy.txt']);
 const matchFiles = qualifyNames(['/mixed/aabbcc.json', '/mixed/ab.json']);
 
@@ -112,6 +113,59 @@ describe('FileHound', () => {
       return query
         .then((files) => {
           assert.deepEqual(files, textFiles);
+        });
+    });
+  });
+
+  describe('.recursive', () => {
+    it('returns files recursively by default when not used', () => {
+      const query = FileHound.create()
+        .ext('json')
+        .paths(fixtureDir + '/nested')
+        .find();
+
+      return query
+        .then((files) => {
+          assert.deepEqual(files, nestedFiles);
+        });
+    });
+
+    it('returns files recursively when no argument is passed', () => {
+      const query = FileHound.create()
+        .ext('json')
+        .paths(fixtureDir + '/nested')
+        .recursive()
+        .find();
+
+      return query
+        .then((files) => {
+          assert.deepEqual(files, nestedFiles);
+        });
+    });
+
+    it('returns files recursively when set to true', () => {
+      const query = FileHound.create()
+        .ext('json')
+        .paths(fixtureDir + '/nested')
+        .recursive(true)
+        .find();
+
+      return query
+        .then((files) => {
+          assert.deepEqual(files, nestedFiles);
+        });
+    });
+
+    it('only returns files within the specified path when set to false', () => {
+      const query = FileHound.create()
+        .ext('json')
+        .paths(fixtureDir + '/nested')
+        .recursive(false)
+        .find();
+
+      return query
+        .then((files) => {
+          assert.deepEqual(files, nestedFilesNonRecursive);
         });
     });
   });


### PR DESCRIPTION
At the moment `filehound` searches through all sub-directories within a given path(s). It would be nice to search within a path, returning files only within the scope of the parent directory and not its children.

Examples:

_Searching with `recursive`, no args (same as default behaviour)_
```js
FileHound.create()
  .paths(__dirname)
  .ext('json')
  .recursive()
  .find();
```

_Searching with `recursive`, set to `true` (same as default behaviour)_
```js
FileHound.create()
  .paths(__dirname)
  .ext('json')
  .recursive(true)
  .find();
```

_Searching with `recursive`, set to `false` (without recursively scanning sub-directories)_
```js
FileHound.create()
  .paths(__dirname)
  .ext('json')
  .recursive(false)
  .find();
```

Also removed a redundant static method from the README (`Filehound.not`)