### PR TITLE
Feature: ignoreHiddenFiles can also filter hidden directories

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,9 +215,10 @@ synonym for .glob
 ##### Returns
 * Returns a FileHound instance
 
-### `.ignoreHiddenFiles() -> FileHound`
+### `.ignoreHiddenFiles(boolean) -> FileHound`
 
-##### Parameters - None
+##### Parameters
+* boolean - Indicates whether hidden directories should be filtered - _default false_
 
 ##### Returns
 * Returns a FileHound instance

--- a/lib/filehound.js
+++ b/lib/filehound.js
@@ -34,6 +34,10 @@ function getDepth(root, dir) {
   return pathDepth(dir) - pathDepth(root);
 }
 
+function isHiddenDirectory(dir) {
+  return (/(^|\/)\.[^\/\.]/g).test(dir);
+}
+
 class FileHound {
   constructor() {
     this.searchPaths = new Set();
@@ -63,6 +67,10 @@ class FileHound {
 
   _atMaxDepth(root, dir) {
     return isDefined(this.maxDepth) && (getDepth(root, dir) > this.maxDepth);
+  }
+
+  _shouldFilterDirectory(root, dir) {
+    return this._atMaxDepth(root, dir) || (this.ignoreHiddenDirectories && isHiddenDirectory(dir));
   }
 
   addFilter(filter) {
@@ -109,7 +117,8 @@ class FileHound {
     return this;
   }
 
-  ignoreHiddenFiles() {
+  ignoreHiddenFiles(includeDirectories) {
+    this.ignoreHiddenDirectories = includeDirectories ? true : false;
     this.addFilter(isVisibleFile);
     return this;
   }
@@ -120,7 +129,7 @@ class FileHound {
   }
 
   _search(root, dir) {
-    if (this._atMaxDepth(root, dir)) return [];
+    if (this._shouldFilterDirectory(root, dir)) return [];
 
     return this._getFiles(dir)
       .map((file) => {

--- a/test/filehound.js
+++ b/test/filehound.js
@@ -409,6 +409,18 @@ describe('FileHound', () => {
         assert.deepEqual(files, qualifyNames(['/visibility/.hidden/visible.json', '/visibility/visible.json']));
       });
     });
+
+    it('strips files within hidden directories when included', () => {
+      const noHiddenFiles = FileHound.create()
+        .ignoreHiddenFiles(true)
+        .paths(fixtureDir + '/visibility')
+        .find();
+
+      noHiddenFiles.then((files) => {
+        assert.equal(files.length, 1);
+        assert.deepEqual(files, qualifyNames(['/visibility/visible.json']));
+      });
+    });
   });
 
   describe('.addFilter', () => {


### PR DESCRIPTION
Uses a `boolean` to indicate whether or not to filter out hidden directories also.

Fixes #10 