### PR TITLE
Feature: matches files by their access times

### DIFF
--- a/src/filehound.js
+++ b/src/filehound.js
@@ -65,7 +65,12 @@ class FileHound {
   }
 
   modified(pattern) {
-    this.addFilter(files.modifiedMatcher(pattern));
+    this.addFilter(files.utimeMatcher(pattern, 'mtime'));
+    return this;
+  }
+
+  accessed(pattern) {
+    this.addFilter(files.utimeMatcher(pattern, 'atime'));
     return this;
   }
 

--- a/src/files.js
+++ b/src/files.js
@@ -90,11 +90,11 @@ export function sizeMatcher(sizeExpression) {
   };
 }
 
-export function modifiedMatcher(pattern) {
+export function utimeMatcher(pattern, utime) {
   const dateCmp = new DateCompare(pattern);
 
   return (file) => {
-    const mtime = getStats(file).mtime;
+    const mtime = getStats(file)[utime];
     return dateCmp.match(mtime);
   };
 }


### PR DESCRIPTION
#19 File accessed time

Example usage:

```js
FileHound.create()
        .paths('/mydir')
        .accessed('<3h')
        .find();
```