### PR TITLE
Feature: can now filter files based on ctime

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,6 +286,13 @@ synonym for .glob
 ##### Returns
 * Returns a FileHound instance
 
+### `.changed(dateExpression) -> FileHound`
+##### Parameters
+* dateExpression (see `.modified`)
+
+##### Returns
+* Returns a FileHound instance
+
 ### `.isEmpty() -> FileHound`
 
 ##### Parameters - None

--- a/package.json
+++ b/package.json
@@ -42,10 +42,11 @@
     "babel-preset-es2015": "^6.1.18",
     "babel-preset-react": "^6.1.18",
     "babel-preset-stage-0": "^6.1.18",
-    "mocha": "^2.3.0",
     "coveralls": "^2.11.8",
     "eslint": "^2.7.0",
-    "istanbul": "^0.4.1"
+    "istanbul": "^0.4.1",
+    "mocha": "^2.3.0",
+    "sinon": "^1.17.4"
   },
   "eslintConfig": {
     "extends": "eslint:recommended",

--- a/src/filehound.js
+++ b/src/filehound.js
@@ -69,6 +69,11 @@ class FileHound {
     return this;
   }
 
+  changed(pattern) {
+    this.addFilter(files.utimeMatcher(pattern, 'ctime'));
+    return this;
+  }
+
   addFilter(filter) {
     this.filters.push(filter);
     return this;


### PR DESCRIPTION
#20 File changed

Just like `accessed` and `modified`, except `fs.statSync` has been stubbed out in the tests, since it's not possible to modify the ctime.