### PR TITLE
Fix: bluebird import in type def

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,5 +1,5 @@
 import { EventEmitter } from "events";
-import Bluebird from "bluebird";
+import * as Bluebird from "bluebird";
 
 declare module 'filehound' {
   class FileHound extends EventEmitter {


### PR DESCRIPTION
If `@types/bluebird` are installed, the current type definitions throw a type error (Fixes #84)